### PR TITLE
Setup Entrance Way API with schema and tests

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -87,9 +87,27 @@ This document is for human and AI agents. If you’re here to build, fix, or ima
 - **Entrance Way Source File:**  
   Please use `/packages/db/seed/the-entrance-way.txt` as the canonical source for all page chunking, seeding, and content tasks.
 
-- **Corpus Symbols:**  
-  All baseline symbols for the Corpus are located in `/the-corpus/symbols/`.  
+- **Corpus Symbols:**
+  All baseline symbols for the Corpus are located in `/the-corpus/symbols/`.
   Each SVG file is named according to its character or archetype. Reference these when building navigation, tagging, or ritual UI elements.
+
+---
+
+## Entrance Way API
+
+tRPC endpoints are served from `/trpc`:
+
+| Procedure | Parameters | Result |
+|-----------|------------|--------|
+| `getPageById` | `{ section: number, index: number }` | `Page \| null` |
+| `getPagesBySection` | `{ section: number }` | `Page[]` |
+| `searchPages` | `{ query: string }` | `Page[]` |
+
+Example using TanStack Query:
+
+```ts
+const page = trpc.getPageById.useQuery({ section: 1, index: 5 });
+```
 
 ---
 

--- a/apps/api/auth/middleware.ts
+++ b/apps/api/auth/middleware.ts
@@ -1,0 +1,9 @@
+import type { MiddlewareHandler } from 'hono';
+
+export const authMiddleware: MiddlewareHandler = async (c, next) => {
+  // Placeholder logic for Better Auth integration
+  const user = { id: 'anon' };
+  c.set('user', user);
+  await next();
+};
+

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1,0 +1,56 @@
+import { Hono } from 'hono';
+import { initTRPC } from '@trpc/server';
+import type { Context } from 'hono';
+import { trpcServer } from '@hono/trpc-server';
+import { drizzle } from 'drizzle-orm/bun-sqlite';
+import { Database } from 'bun:sqlite';
+import { pages } from '../../packages/db/src/schema';
+import { eq, and, like } from 'drizzle-orm';
+import { z } from 'zod';
+import { authMiddleware } from '../auth/middleware';
+
+export const db = drizzle(new Database('db.sqlite'));
+
+export type AppContext = Context & { user: unknown };
+const t = initTRPC.context<AppContext>().create();
+
+export const appRouter = t.router({
+  getPageById: t.procedure
+    .input(
+      z.object({ section: z.number(), index: z.number() })
+    )
+    .query(async ({ input }) => {
+      const result = await db
+        .select()
+        .from(pages)
+        .where(and(eq(pages.section, input.section), eq(pages.pageNumber, input.index)));
+      return result[0] ?? null;
+    }),
+
+  getPagesBySection: t.procedure
+    .input(z.object({ section: z.number() }))
+    .query(async ({ input }) => {
+      return await db
+        .select()
+        .from(pages)
+        .where(eq(pages.section, input.section));
+    }),
+
+  searchPages: t.procedure
+    .input(z.object({ query: z.string() }))
+    .query(async ({ input }) => {
+      return await db
+        .select()
+        .from(pages)
+        .where(like(pages.text, `%${input.query}%`));
+    }),
+});
+
+export type AppRouter = typeof appRouter;
+
+export const app = new Hono<AppContext>();
+
+app.use('/trpc/*', authMiddleware);
+app.use('/trpc/*', trpcServer({ router: appRouter }));
+
+

--- a/package.json
+++ b/package.json
@@ -1,4 +1,9 @@
 {
-    "name": "gibsey-root",
-    "version": "1.0.0"
-  }  
+  "name": "gibsey-root",
+  "version": "1.0.0",
+  "scripts": {
+    "seed": "bun run packages/db/seed/index.ts",
+    "test": "bun test"
+  }
+}
+

--- a/packages/db/seed/index.ts
+++ b/packages/db/seed/index.ts
@@ -1,0 +1,49 @@
+import { Database } from 'bun:sqlite';
+import { drizzle } from 'drizzle-orm/bun-sqlite';
+import { pages, sections } from '../src/schema';
+import { readFile } from 'fs/promises';
+
+const db = drizzle(new Database('db.sqlite'));
+
+async function seed() {
+  const sectionMap: Array<{ section: number; section_name: string }> = JSON.parse(
+    await readFile(new URL('./entrance-way-section-map.json', import.meta.url), 'utf8'),
+  );
+
+  for (const s of sectionMap) {
+    await db.insert(sections).values({ id: s.section, sectionName: s.section_name });
+  }
+
+  const pagesData: Array<{
+    global_index: number;
+    page_number: number;
+    section: string | null;
+    text: string;
+  }> = JSON.parse(
+    await readFile(new URL('./the-entrance-way-pages.json', import.meta.url), 'utf8'),
+  );
+
+  let currentSection = sectionMap[0].section_name;
+  for (const page of pagesData) {
+    if (page.section) currentSection = page.section;
+    const sectionRecord = sectionMap.find(
+      (s) => s.section_name.toLowerCase() === currentSection.toLowerCase(),
+    );
+    if (!sectionRecord) continue;
+
+    await db.insert(pages).values({
+      id: page.global_index,
+      section: sectionRecord.section,
+      sectionName: currentSection,
+      pageNumber: page.page_number,
+      globalIndex: page.global_index,
+      text: page.text,
+    });
+  }
+}
+
+seed().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,0 +1,28 @@
+import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core';
+import { relations } from 'drizzle-orm';
+
+export const sections = sqliteTable('sections', {
+  id: integer('id').primaryKey(),
+  sectionName: text('section_name').notNull(),
+});
+
+export const pages = sqliteTable('pages', {
+  id: integer('id').primaryKey(),
+  section: integer('section').references(() => sections.id).notNull(),
+  sectionName: text('section_name').notNull(),
+  pageNumber: integer('page_number').notNull(),
+  globalIndex: integer('global_index').notNull().unique(),
+  text: text('text').notNull(),
+});
+
+export const sectionRelations = relations(sections, ({ many }) => ({
+  pages: many(pages),
+}));
+
+export const pageRelations = relations(pages, ({ one }) => ({
+  section: one(sections, {
+    fields: [pages.section],
+    references: [sections.id],
+  }),
+}));
+

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,1 +1,11 @@
 Common TypeScript types and interfaces shared across the Gibsey project.
+
+### Entrance Way
+
+`entrance-way.ts` defines the core data transfer objects (DTOs) used by the Entrance Way API.
+
+- `Section` – basic info about a section of the text.
+- `Page` – one page within a section with its text and indexes.
+- `GetPageByIdParams`, `GetPagesBySectionParams`, `SearchPagesParams` – input shapes for the API procedures.
+- `GetPageByIdResult`, `GetPagesBySectionResult`, `SearchPagesResult` – return types from the API.
+

--- a/packages/types/entrance-way.ts
+++ b/packages/types/entrance-way.ts
@@ -1,0 +1,31 @@
+export interface Section {
+  id: number;
+  sectionName: string;
+}
+
+export interface Page {
+  id: number;
+  section: number;
+  sectionName: string;
+  pageNumber: number;
+  globalIndex: number;
+  text: string;
+}
+
+export interface GetPageByIdParams {
+  section: number;
+  index: number;
+}
+
+export interface GetPagesBySectionParams {
+  section: number;
+}
+
+export interface SearchPagesParams {
+  query: string;
+}
+
+export type GetPageByIdResult = Page | null;
+export type GetPagesBySectionResult = Page[];
+export type SearchPagesResult = Page[];
+

--- a/tests/unit/api/entrance-way.test.ts
+++ b/tests/unit/api/entrance-way.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as router from '../../../apps/api/src/router';
+
+const mockDb = {
+  select: vi.fn().mockReturnThis(),
+  from: vi.fn().mockReturnThis(),
+  where: vi.fn(),
+};
+
+beforeEach(() => {
+  mockDb.select.mockReturnThis();
+  mockDb.from.mockReturnThis();
+  router.db.select = mockDb.select as any;
+  router.db.from = mockDb.from as any;
+  router.db.where = mockDb.where as any;
+});
+
+describe('getPageById', () => {
+  it('returns page when found', async () => {
+    mockDb.where.mockResolvedValue([{ id: 1 }]);
+    const caller = router.appRouter.createCaller({ user: null } as any);
+    const result = await caller.getPageById({ section: 1, index: 1 });
+    expect(result).toEqual({ id: 1 });
+  });
+
+  it('returns null when not found', async () => {
+    mockDb.where.mockResolvedValue([]);
+    const caller = router.appRouter.createCaller({ user: null } as any);
+    const result = await caller.getPageById({ section: 1, index: 2 });
+    expect(result).toBeNull();
+  });
+});
+
+describe('getPagesBySection', () => {
+  it('returns pages list', async () => {
+    const pages = [{ id: 1 }, { id: 2 }];
+    mockDb.where.mockResolvedValue(pages);
+    const caller = router.appRouter.createCaller({ user: null } as any);
+    const result = await caller.getPagesBySection({ section: 1 });
+    expect(result).toEqual(pages);
+  });
+});
+
+describe('searchPages', () => {
+  it('returns matched pages', async () => {
+    const pages = [{ id: 3 }];
+    mockDb.where.mockResolvedValue(pages);
+    const caller = router.appRouter.createCaller({ user: null } as any);
+    const result = await caller.searchPages({ query: 'hello' });
+    expect(result).toEqual(pages);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Drizzle schema for Entrance Way pages and sections
- seed database from Entrance Way JSON files
- implement tRPC router with Hono and Better Auth stub
- provide shared TypeScript DTOs for the API
- document endpoints in AGENTS.md and DTOs in package docs
- create Vitest unit tests (fail due to missing dependencies)

## Testing
- `bun run test` *(fails: Cannot find package 'hono')*