### PR TITLE
Add regeneration steps for the-entrance-way pages

### DIFF
--- a/docs/scratchpad.md
+++ b/docs/scratchpad.md
@@ -53,3 +53,20 @@ Issue: the heading on page 9 is parsed as "London Fox Who Dreams of Synchronisti
 
 - Attempted to open the built site in Chrome and Firefox to verify navigation and styling.
 - The container environment lacks GUI browsers, so cross-browser behavior could not be confirmed.
+
+## 2025-05-20 – Regenerating `the-entrance-way-pages.json`
+
+Steps to rebuild the pages file from the canonical text:
+
+1. Ensure **Python 3.11+** is available (the repo ships with a `.venv` under `services/ai/`). Activate it or use your system interpreter.
+2. Navigate to `packages/db/seed/`.
+3. Run the CLI-enhanced script:
+
+   ```bash
+   python chunk_entrance_way.py --source the-entrance-way.txt --output the-entrance-way-pages.json --section-map entrance-way-section-map.json
+   ```
+
+   The command prints how many pages were written and supports `--source`, `--output`, and `--section-map` options.
+4. Verify the new JSON aligns with `entrance-way-section-map.json`.
+
+The heading on **page 9** is parsed as "London Fox Who Dreams of Synchronistic Extraction" while the mapping file lists "London Fox Who Vertically Disintegrates". Keep the mapping value as canonical.


### PR DESCRIPTION
## Summary
- document how to regenerate `the-entrance-way-pages.json`
- mention page 9 heading mismatch and CLI usage

## Testing
- `bun test` *(fails: Cannot find package 'hono')*